### PR TITLE
[#1] Add Connection Concurrent Handling via Goroutine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ run:
 	FLOCK_ENV=development go run ./cmd/flock
 
 test:
-	go test ./...
+	go test ./... -race
 
 fmt:
 	go fmt ./...

--- a/flock.example.yaml
+++ b/flock.example.yaml
@@ -2,7 +2,7 @@ network:
     port: 8080
 
 routes:
-    - path: /
+    - path: /health
       methods: [GET]
       health:
           code: 200

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -34,11 +34,11 @@ type HandlerHealthOptions struct {
 }
 
 type RouteConfig struct {
-	Path            string                  `yaml:"path"`
-	Methods         []protocol.Method       `yaml:"methods"`
 	StatusOptions   *HandlerStatusOptions   `yaml:"status,omitempty"`
 	RedirectOptions *HandlerRedirectOptions `yaml:"redirect,omitempty"`
 	HealthOptions   *HandlerHealthOptions   `yaml:"health,omitempty"`
+	Path            string                  `yaml:"path"`
+	Methods         []protocol.Method       `yaml:"methods"`
 }
 
 type RoutesConfig []RouteConfig

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -104,7 +104,7 @@ func TestLoad_DefaultConfigWhenPathEmpty(t *testing.T) {
 		t.Fatalf("got %d routes, want 1", len(cfg.Routes))
 	}
 
-	if cfg.Routes[0].Path != "/" {
+	if cfg.Routes[0].Path != "/health" {
 		t.Fatalf("got route path %q, want /", cfg.Routes[0].Path)
 	}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -105,7 +105,7 @@ func TestLoad_DefaultConfigWhenPathEmpty(t *testing.T) {
 	}
 
 	if cfg.Routes[0].Path != "/health" {
-		t.Fatalf("got route path %q, want /", cfg.Routes[0].Path)
+		t.Fatalf("got route path %q, want /health", cfg.Routes[0].Path)
 	}
 
 	if cfg.Routes[0].HealthOptions == nil {

--- a/internal/config/default.yaml
+++ b/internal/config/default.yaml
@@ -2,7 +2,7 @@ network:
     port: 8080
 
 routes:
-    - path: /
+    - path: /health
       methods: [GET]
       health:
           code: 200

--- a/internal/http/request.go
+++ b/internal/http/request.go
@@ -119,6 +119,10 @@ func parseHeaders(reader *bufio.Reader) (map[string]string, *errors.OpError) {
 		key := strings.TrimSpace(line[:colonIndex])
 		value := strings.TrimSpace(line[colonIndex+1:])
 
+		if key == "" {
+			return nil, errors.New(errors.MalformedHeaderKind, "parse headers", "header key is empty")
+		}
+
 		headers[textproto.CanonicalMIMEHeaderKey(key)] = value
 	}
 

--- a/internal/http/request.go
+++ b/internal/http/request.go
@@ -86,7 +86,7 @@ func parseRequestLine(line string) (protocol.Method, string, protocol.Version, *
 // parseHeaders reads header lines until the terminating blank line.
 //
 // Header keys are canonicalized using MIME header casing, and malformed lines
-// without a separating colon are ignored.
+// without a separating colon are rejected.
 func parseHeaders(reader *bufio.Reader) (map[string]string, *errors.OpError) {
 	const maxHeaders = 100
 	const initialHeadersMapSize = 16
@@ -112,7 +112,7 @@ func parseHeaders(reader *bufio.Reader) (map[string]string, *errors.OpError) {
 		}
 
 		colonIndex := strings.IndexByte(line, ':')
-		if colonIndex <= 0 { // TODO: do not skip, reject with 400
+		if colonIndex <= 0 {
 			return nil, errors.New(errors.MalformedHeaderKind, "parse headers", "missing header key-value pair colon")
 		}
 

--- a/internal/http/request_test.go
+++ b/internal/http/request_test.go
@@ -6,18 +6,18 @@ import (
 	"strings"
 	"testing"
 
-	flockerrors "github.com/harshithl1777/flock/internal/errors"
+	"github.com/harshithl1777/flock/internal/errors"
 	"github.com/harshithl1777/flock/internal/protocol"
 )
 
-func assertRequestErrorKind(t *testing.T, err error, want flockerrors.ErrorKind) {
+func assertRequestErrorKind(t *testing.T, err error, want errors.ErrorKind) {
 	t.Helper()
 
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
 
-	var opErr *flockerrors.OpError
+	var opErr *errors.OpError
 	if !stderrors.As(err, &opErr) {
 		t.Fatalf("expected *errors.OpError, got %T", err)
 	}
@@ -74,14 +74,14 @@ func TestReadRequest_InvalidRequestLine(t *testing.T) {
 	raw := "TRACE / HTTP/1.1\r\nHost: localhost\r\n\r\n"
 
 	_, err := ReadRequest(bufio.NewReader(strings.NewReader(raw)))
-	assertRequestErrorKind(t, err, flockerrors.UnsupportedHTTPMethodKind)
+	assertRequestErrorKind(t, err, errors.UnsupportedHTTPMethodKind)
 }
 
 func TestReadRequest_RejectsUnsupportedHTTPVersion(t *testing.T) {
 	raw := "GET / HTTP/2.0\r\nHost: localhost\r\n\r\n"
 
 	_, err := ReadRequest(bufio.NewReader(strings.NewReader(raw)))
-	assertRequestErrorKind(t, err, flockerrors.UnsupportedHTTPVersionKind)
+	assertRequestErrorKind(t, err, errors.UnsupportedHTTPVersionKind)
 }
 
 func TestReadRequest_RejectsChunkedTransferEncoding(t *testing.T) {
@@ -92,7 +92,17 @@ func TestReadRequest_RejectsChunkedTransferEncoding(t *testing.T) {
 		"\r\n"
 
 	_, err := ReadRequest(bufio.NewReader(strings.NewReader(raw)))
-	assertRequestErrorKind(t, err, flockerrors.UnsupportedTransferEncodingKind)
+	assertRequestErrorKind(t, err, errors.UnsupportedTransferEncodingKind)
+}
+
+func TestReadRequest_RejectsMalformedHeader(t *testing.T) {
+	raw := "" +
+		"GET / HTTP/1.1\r\n" +
+		"Host localhost\r\n" +
+		"\r\n"
+
+	_, err := ReadRequest(bufio.NewReader(strings.NewReader(raw)))
+	assertRequestErrorKind(t, err, errors.MalformedHeaderKind)
 }
 
 func TestReadRequest_RequiresHostHeader(t *testing.T) {
@@ -101,5 +111,5 @@ func TestReadRequest_RequiresHostHeader(t *testing.T) {
 		"\r\n"
 
 	_, err := ReadRequest(bufio.NewReader(strings.NewReader(raw)))
-	assertRequestErrorKind(t, err, flockerrors.MissingHostKind)
+	assertRequestErrorKind(t, err, errors.MissingHostKind)
 }

--- a/internal/http/request_test.go
+++ b/internal/http/request_test.go
@@ -105,6 +105,16 @@ func TestReadRequest_RejectsMalformedHeader(t *testing.T) {
 	assertRequestErrorKind(t, err, errors.MalformedHeaderKind)
 }
 
+func TestReadRequest_RejectsEmptyHeaderKey(t *testing.T) {
+	raw := "" +
+		"GET / HTTP/1.1\r\n" +
+		": localhost\r\n" +
+		"\r\n"
+
+	_, err := ReadRequest(bufio.NewReader(strings.NewReader(raw)))
+	assertRequestErrorKind(t, err, errors.MalformedHeaderKind)
+}
+
 func TestReadRequest_RequiresHostHeader(t *testing.T) {
 	raw := "" +
 		"GET / HTTP/1.1\r\n" +
@@ -112,4 +122,27 @@ func TestReadRequest_RequiresHostHeader(t *testing.T) {
 
 	_, err := ReadRequest(bufio.NewReader(strings.NewReader(raw)))
 	assertRequestErrorKind(t, err, errors.MissingHostKind)
+}
+
+func TestReadRequest_RejectsInvalidContentLength(t *testing.T) {
+	raw := "" +
+		"POST /submit HTTP/1.1\r\n" +
+		"Host: localhost\r\n" +
+		"Content-Length: nope\r\n" +
+		"\r\n"
+
+	_, err := ReadRequest(bufio.NewReader(strings.NewReader(raw)))
+	assertRequestErrorKind(t, err, errors.InvalidContentLengthKind)
+}
+
+func TestReadRequest_RejectsIncompleteBody(t *testing.T) {
+	raw := "" +
+		"POST /submit HTTP/1.1\r\n" +
+		"Host: localhost\r\n" +
+		"Content-Length: 5\r\n" +
+		"\r\n" +
+		"hey"
+
+	_, err := ReadRequest(bufio.NewReader(strings.NewReader(raw)))
+	assertRequestErrorKind(t, err, errors.IncompleteBodyKind)
 }

--- a/internal/http/response_test.go
+++ b/internal/http/response_test.go
@@ -2,12 +2,12 @@ package http
 
 import (
 	"bytes"
-	errors "errors"
+	stderrors "errors"
 	"io"
 	"strings"
 	"testing"
 
-	stderrors "github.com/harshithl1777/flock/internal/errors"
+	"github.com/harshithl1777/flock/internal/errors"
 	"github.com/harshithl1777/flock/internal/protocol"
 )
 
@@ -115,7 +115,7 @@ func TestNewJSONResponse_SerializesBody(t *testing.T) {
 }
 
 func TestNewErrorResponse_MapsBodyTooLargeToBadRequest(t *testing.T) {
-	response, err := NewErrorResponse(stderrors.New(stderrors.BodyTooLargeKind, "parse body", "too large"))
+	response, err := NewErrorResponse(errors.New(errors.BodyTooLargeKind, "parse body", "too large"))
 	if err != nil {
 		t.Fatalf("NewErrorResponse returned error: %v", err)
 	}
@@ -155,7 +155,7 @@ func TestWriteTo_PropagatesWriterErrorAndPartialCount(t *testing.T) {
 	response := NewTextResponse(protocol.StatusOK, "Hello World!")
 	response.Headers[protocol.HeaderContentLength] = "999"
 
-	expected := errors.New("write failed")
+	expected := stderrors.New("write failed")
 	writer := &failAfterNWriter{
 		remaining: 16,
 		err:       expected,
@@ -163,7 +163,7 @@ func TestWriteTo_PropagatesWriterErrorAndPartialCount(t *testing.T) {
 
 	n, err := response.WriteTo(writer)
 
-	if !errors.Is(err, expected) {
+	if !stderrors.Is(err, expected) {
 		t.Fatalf("expected WriteTo to return the original writer error, got %v", err)
 	}
 

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -71,6 +71,11 @@ func String(key, value string) zap.Field {
 	return zap.String(key, value)
 }
 
+// ByteString constructs a string field from bytes for structured logs.
+func ByteString(key string, value []byte) zap.Field {
+	return zap.ByteString(key, value)
+}
+
 // Int constructs an integer field for structured logs.
 func Int(key string, value int) zap.Field {
 	return zap.Int(key, value)

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -29,7 +29,12 @@ func mustNewLogger(env string, sink zapcore.WriteSyncer, colorize bool) *zap.Log
 // newLogger builds a zap logger for the configured environment.
 func newLogger(env string, sink zapcore.WriteSyncer, colorize bool) *zap.Logger {
 	encoder := newEncoder(env, colorize)
-	core := zapcore.NewCore(encoder, sink, zap.InfoLevel)
+	level := zap.InfoLevel
+	if os.Getenv("FLOCK_DISABLE_LOGGING") == "true" {
+		level = zap.FatalLevel
+	}
+
+	core := zapcore.NewCore(encoder, sink, level)
 	if env == "development" {
 		core = &messagePaddingCore{Core: core, width: messageWidth}
 	}

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -120,6 +120,7 @@ func TestErr_OpErrorUsesStructuredObject(t *testing.T) {
 }
 
 func TestByteString_LogsBytesAsString(t *testing.T) {
+	t.Setenv("FLOCK_DISABLE_LOGGING", "false")
 	var buf bytes.Buffer
 
 	log := newLogger("production", zapcore.AddSync(&buf), false)

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -119,6 +119,25 @@ func TestErr_OpErrorUsesStructuredObject(t *testing.T) {
 	}
 }
 
+func TestByteString_LogsBytesAsString(t *testing.T) {
+	var buf bytes.Buffer
+
+	log := newLogger("production", zapcore.AddSync(&buf), false)
+
+	log.Error("panic recovered", ByteString("stack", []byte("goroutine 1\nmain.main")))
+
+	got := strings.TrimSpace(buf.String())
+
+	var decoded map[string]any
+	if err := json.Unmarshal([]byte(got), &decoded); err != nil {
+		t.Fatalf("expected JSON log output, got %q: %v", got, err)
+	}
+
+	if decoded["stack"] != "goroutine 1\nmain.main" {
+		t.Fatalf("got stack %v, want byte string stack", decoded["stack"])
+	}
+}
+
 func TestNewLogger_DevelopmentAlignsJSONContextColumn(t *testing.T) {
 	var buf bytes.Buffer
 

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -22,13 +22,67 @@ type Router struct {
 	routes []Route
 }
 
-// Resolve returns either a ready-to-write response for router-owned outcomes
-// or the matched handler for normal request dispatch.
-func (r *Router) Resolve(method protocol.Method, path string) (handler.Handler, *http.Response) {
+// RoutingDecision classifies how the caller should handle a matched request.
+type RoutingDecision uint16
+
+const (
+	Forward RoutingDecision = iota
+	Options
+	NotFound
+	MethodNotAllowed
+)
+
+// Match captures the best route lookup result along with any routing error.
+type Match struct {
+	Route    *Route
+	Err      *errors.OpError
+	Decision RoutingDecision
+}
+
+// Resolve returns the best route match together with the caller action needed
+// to complete request handling.
+func (r *Router) Resolve(method protocol.Method, path string) Match {
+	pathMatch, methodMatch := r.match(method, path)
+
+	var decision RoutingDecision
+	var route *Route
+	var err *errors.OpError
+
+	if method == protocol.Options && pathMatch != nil {
+		route = pathMatch
+		decision = Options
+	} else if methodMatch != nil {
+		route = methodMatch
+		decision = Forward
+	} else if pathMatch != nil {
+		route = pathMatch
+		decision = MethodNotAllowed
+		err = errors.Newf(
+			errors.MethodNotAllowedKind,
+			"match request route",
+			"requested method %s not allowed",
+			method,
+		)
+	} else {
+		decision = NotFound
+		err = errors.Newf(
+			errors.NotFoundKind,
+			"match request route",
+			"no matching route found for %s %s",
+			method,
+			path,
+		)
+	}
+
+	return Match{Route: route, Decision: decision, Err: err}
+}
+
+// match returns the longest path match and the longest method-allowed match.
+func (r *Router) match(method protocol.Method, path string) (*Route, *Route) {
 	path = normalizePath(path)
 
-	var bestPathMatch *Route
-	var bestAllowedMatch *Route
+	var pathMatch *Route
+	var methodMatch *Route
 
 	for i := range r.routes {
 		route := &r.routes[i]
@@ -44,35 +98,20 @@ func (r *Router) Resolve(method protocol.Method, path string) (handler.Handler, 
 			}
 		}
 
-		if bestPathMatch == nil || len(route.Path) > len(bestPathMatch.Path) {
-			bestPathMatch = route
+		if pathMatch == nil || len(route.Path) > len(pathMatch.Path) {
+			pathMatch = route
 		}
 
 		if !route.Methods.Allows(method) {
 			continue
 		}
 
-		if bestAllowedMatch == nil || len(route.Path) > len(bestAllowedMatch.Path) {
-			bestAllowedMatch = route
+		if methodMatch == nil || len(route.Path) > len(methodMatch.Path) {
+			methodMatch = route
 		}
 	}
 
-	if method == protocol.Options && bestPathMatch != nil {
-		return nil, http.NewStatusResponse(protocol.StatusNoContent).
-			WithHeader(protocol.HeaderAllow, bestPathMatch.AllowHeader)
-	}
-
-	if bestAllowedMatch != nil {
-		return bestAllowedMatch.Handler, nil
-	}
-
-	if bestPathMatch == nil {
-		return nil, newErrorResponse(errors.Newf(errors.NotFoundKind, "match request route", "no matching route found for %s %s", method, path))
-	}
-
-	return nil, newErrorResponse(
-		errors.Newf(errors.MethodNotAllowedKind, "match request route", "requested method %s not allowed", method),
-	).WithHeader(protocol.HeaderAllow, bestPathMatch.AllowHeader)
+	return pathMatch, methodMatch
 }
 
 // New builds the runtime router from the validated configuration routes.

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/harshithl1777/flock/internal/config"
+	"github.com/harshithl1777/flock/internal/errors"
 	"github.com/harshithl1777/flock/internal/protocol"
 )
 
@@ -27,81 +28,97 @@ func newTestRouter() *Router {
 }
 
 func TestResolve_Dispatch(t *testing.T) {
-	routeHandler, errResponse := newTestRouter().Resolve(protocol.Get, "/")
+	match := newTestRouter().Resolve(protocol.Get, "/")
 
-	if errResponse != nil {
-		t.Fatalf("got errResponse %v, want nil", errResponse)
+	if match.Err != nil {
+		t.Fatalf("got err %v, want nil", match.Err)
 	}
 
-	if routeHandler == nil {
+	if match.Decision != Forward {
+		t.Fatalf("got decision %v, want %v", match.Decision, Forward)
+	}
+
+	if match.Route == nil {
 		t.Fatal("expected matched handler")
 	}
 }
 
 func TestResolve_HeadAllowedByGet(t *testing.T) {
-	routeHandler, errResponse := newTestRouter().Resolve(protocol.Head, "/")
+	match := newTestRouter().Resolve(protocol.Head, "/")
 
-	if errResponse != nil {
-		t.Fatalf("got errResponse %v, want nil", errResponse)
+	if match.Err != nil {
+		t.Fatalf("got err %v, want nil", match.Err)
 	}
 
-	if routeHandler == nil {
+	if match.Decision != Forward {
+		t.Fatalf("got decision %v, want %v", match.Decision, Forward)
+	}
+
+	if match.Route == nil {
 		t.Fatal("expected matched handler")
 	}
 }
 
 func TestResolve_MethodNotAllowed(t *testing.T) {
-	routeHandler, errResponse := newTestRouter().Resolve(protocol.Post, "/")
+	match := newTestRouter().Resolve(protocol.Post, "/")
 
-	if routeHandler != nil {
-		t.Fatalf("got handler %v, want nil", routeHandler)
+	if match.Route == nil {
+		t.Fatal("expected matched route for allow header")
 	}
 
-	if errResponse == nil {
-		t.Fatal("expected method not allowed errResponse")
+	if match.Err == nil {
+		t.Fatal("expected method not allowed err")
 	}
 
-	if errResponse.StatusCode != int(protocol.StatusMethodNotAllowed) {
-		t.Fatalf("got status %d, want %d", errResponse.StatusCode, protocol.StatusMethodNotAllowed)
+	if match.Decision != MethodNotAllowed {
+		t.Fatalf("got decision %v, want %v", match.Decision, MethodNotAllowed)
 	}
 
-	if got := errResponse.Headers[protocol.HeaderAllow]; got != "GET, HEAD" {
-		t.Fatalf("got allow header %q, want %q", got, "GET, HEAD")
+	if match.Err.Kind != errors.MethodNotAllowedKind {
+		t.Fatalf("got error kind %v, want %v", match.Err.Kind, errors.MethodNotAllowedKind)
+	}
+
+	if match.Route.AllowHeader != "GET, HEAD" {
+		t.Fatalf("got allow header %q, want %q", match.Route.AllowHeader, "GET, HEAD")
 	}
 }
 
-func TestResolve_OptionsReturnsOptionsDecision(t *testing.T) {
-	routeHandler, errResponse := newTestRouter().Resolve(protocol.Options, "/")
+func TestResolve_OptionsUsesPathMatch(t *testing.T) {
+	match := newTestRouter().Resolve(protocol.Options, "/")
 
-	if routeHandler != nil {
-		t.Fatalf("got handler %v, want nil", routeHandler)
+	if match.Route == nil {
+		t.Fatal("expected options route match")
 	}
 
-	if errResponse == nil {
-		t.Fatal("expected options errResponse")
+	if match.Err != nil {
+		t.Fatalf("got err %v, want nil", match.Err)
 	}
 
-	if errResponse.StatusCode != int(protocol.StatusNoContent) {
-		t.Fatalf("got status %d, want %d", errResponse.StatusCode, protocol.StatusNoContent)
+	if match.Decision != Options {
+		t.Fatalf("got decision %v, want %v", match.Decision, Options)
 	}
 
-	if got := errResponse.Headers[protocol.HeaderAllow]; got != "GET, HEAD" {
-		t.Fatalf("got allow header %q, want %q", got, "GET, HEAD")
+	if match.Route.AllowHeader != "GET, HEAD" {
+		t.Fatalf("got allow header %q, want %q", match.Route.AllowHeader, "GET, HEAD")
 	}
 }
 
 func TestResolve_NotFound(t *testing.T) {
-	routeHandler, errResponse := newTestRouter().Resolve(protocol.Get, "/missing")
+	match := newTestRouter().Resolve(protocol.Get, "/missing")
 
-	if routeHandler != nil {
-		t.Fatalf("got handler %v, want nil", routeHandler)
+	if match.Route != nil {
+		t.Fatalf("got route %v, want nil", match.Route)
 	}
 
-	if errResponse == nil {
-		t.Fatal("expected not found errResponse")
+	if match.Err == nil {
+		t.Fatal("expected not found err")
 	}
 
-	if errResponse.StatusCode != int(protocol.StatusNotFound) {
-		t.Fatalf("got status %d, want %d", errResponse.StatusCode, protocol.StatusNotFound)
+	if match.Decision != NotFound {
+		t.Fatalf("got decision %v, want %v", match.Decision, NotFound)
+	}
+
+	if match.Err.Kind != errors.NotFoundKind {
+		t.Fatalf("got error kind %v, want %v", match.Err.Kind, errors.NotFoundKind)
 	}
 }

--- a/internal/server/connection.go
+++ b/internal/server/connection.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"net"
+	"runtime/debug"
 	"sync/atomic"
 	"time"
 
@@ -17,46 +18,58 @@ import (
 
 type Connection struct {
 	net.Conn
-	router *router.Router
-	log    *zap.Logger
-	remote string
+	reader       *bufio.Reader
+	router       *router.Router
+	log          *zap.Logger
+	remote       string
+	bytesWritten int64
 }
 
 type RequestContext struct {
+	log     *zap.Logger
 	id      string
 	startTs time.Time
-	log     *zap.Logger
 }
 
 // serve reads one request, resolves it through the router, writes the response,
 // and closes the connection.
 func (c *Connection) serve() {
-	defer func() {
-		c.Close()
-		c.log.Info("close connection")
-	}()
-
+	ctx := newRequestContext()
 	c.log.Info("accept connection")
 
-	ctx := newRequestContext()
+	defer func() {
+		recovered := recover()
+		if recovered == nil {
+			c.Close()
+			c.log.Info("close connection")
+			return
+		}
+
+		ctx.log.Error(
+			"connection panic",
+			logger.Any("panic", recovered),
+			logger.ByteString("stack", debug.Stack()),
+		)
+
+		if c.bytesWritten == 0 {
+			c.panicWrite(ctx)
+		}
+
+		c.Close()
+		c.log.Info("close connection after panic")
+	}()
+
 	ctx.log.Info("serve new request")
 
-	reader := bufio.NewReader(c)
-	req, err := http.ReadRequest(reader)
-
+	req, err := http.ReadRequest(c.reader)
 	if err != nil {
-		c.fail(ctx, err)
+		c.failWrite(ctx, err)
 		return
 	}
 
-	handler, errResp := c.router.Resolve(req.Method, req.Path)
-	if errResp != nil {
-		c.write(ctx, errResp, nil)
-		return
-	}
-
-	if handler == nil {
-		c.write(ctx, http.NewStatusResponse(protocol.StatusInternalServerError), nil)
+	match := c.router.Resolve(req.Method, req.Path)
+	if match.Decision != router.Forward {
+		c.routerWrite(ctx, match)
 		return
 	}
 
@@ -64,15 +77,43 @@ func (c *Connection) serve() {
 		"route request",
 		logger.String("method", string(req.Method)),
 		logger.String("path", req.Path),
-		logger.String("handler", handler.Name()),
+		logger.String("handler", match.Route.Handler.Name()),
 	)
 
-	resp := handler.Handle(req)
-	c.write(ctx, resp, nil)
+	resp := match.Route.Handler.Handle(req)
+	c.successWrite(ctx, resp)
 }
 
-// fail converts an operational error into an HTTP error response and writes it.
-func (c *Connection) fail(ctx *RequestContext, err *errors.OpError) {
+// successWrite records a successful handler response with no associated error.
+func (c *Connection) successWrite(ctx *RequestContext, r *http.Response) {
+	c.write(ctx, r, nil)
+}
+
+// routerWrite converts a router-owned decision into its HTTP response.
+func (c *Connection) routerWrite(ctx *RequestContext, match router.Match) {
+	var r *http.Response
+	var allow string
+
+	if match.Route != nil {
+		allow = match.Route.AllowHeader
+	}
+
+	switch match.Decision {
+	case router.Options:
+		r = http.NewStatusResponse(protocol.StatusNoContent).
+			WithHeader(protocol.HeaderAllow, allow)
+	case router.MethodNotAllowed:
+		r = http.NewStatusResponse(protocol.StatusMethodNotAllowed).
+			WithHeader(protocol.HeaderAllow, allow)
+	default:
+		r = http.NewStatusResponse(protocol.StatusNotFound)
+	}
+
+	c.write(ctx, r, match.Err)
+}
+
+// failWrite converts an operational error into an HTTP error response and writes it.
+func (c *Connection) failWrite(ctx *RequestContext, err *errors.OpError) {
 	r, marshalErr := http.NewErrorResponse(err)
 	if marshalErr != nil {
 		r = http.NewStatusResponse(protocol.StatusInternalServerError)
@@ -82,6 +123,21 @@ func (c *Connection) fail(ctx *RequestContext, err *errors.OpError) {
 	c.write(ctx, r, err)
 }
 
+// panicWrite emits a generic 500 response after a panic that occurred before
+// any bytes were written to the connection.
+func (c *Connection) panicWrite(ctx *RequestContext) {
+	resp := http.NewStatusResponse(protocol.StatusInternalServerError)
+	c.write(
+		ctx,
+		resp,
+		errors.New(
+			errors.InternalServerErrorKind,
+			"connection",
+			"encountered connection panic before write",
+		),
+	)
+}
+
 // write attaches the standard server headers, writes the response to the
 // connection, and records the result in the request log.
 func (c *Connection) write(ctx *RequestContext, r *http.Response, err *errors.OpError) {
@@ -89,7 +145,8 @@ func (c *Connection) write(ctx *RequestContext, r *http.Response, err *errors.Op
 		WithHeader(protocol.HeaderXRequestId, ctx.id).
 		WithHeader(protocol.HeaderConnection, "close")
 
-	_, writeErr := r.WriteTo(c)
+	n, writeErr := r.WriteTo(c)
+	c.bytesWritten += n
 
 	log := ctx.log.With(
 		logger.Int("status", r.StatusCode),
@@ -101,13 +158,10 @@ func (c *Connection) write(ctx *RequestContext, r *http.Response, err *errors.Op
 		return
 	}
 
-	if err != nil {
-		log.Info(
-			"send error response",
-			logger.Err(err),
-		)
+	if err == nil {
+		log.Info("send response")
 	} else {
-		log.Info("send success response")
+		log.Info("send error response", logger.Err(err))
 	}
 }
 
@@ -116,6 +170,7 @@ func NewConnection(netConn net.Conn, router *router.Router) *Connection {
 	remoteAddr := netConn.RemoteAddr().String()
 	return &Connection{
 		Conn:   netConn,
+		reader: bufio.NewReader(netConn),
 		router: router,
 		log:    logger.With(logger.String("remote", remoteAddr)),
 		remote: remoteAddr,

--- a/internal/server/connection.go
+++ b/internal/server/connection.go
@@ -31,9 +31,16 @@ type RequestContext struct {
 	startTs time.Time
 }
 
+func (c *Connection) init() {
+	if c.reader == nil {
+		c.reader = bufio.NewReader(c.Conn)
+	}
+}
+
 // serve reads one request, resolves it through the router, writes the response,
 // and closes the connection.
 func (c *Connection) serve() {
+	c.init()
 	ctx := newRequestContext()
 	c.log.Info("accept connection")
 

--- a/internal/server/connection.go
+++ b/internal/server/connection.go
@@ -93,6 +93,7 @@ func (c *Connection) successWrite(ctx *RequestContext, r *http.Response) {
 func (c *Connection) routerWrite(ctx *RequestContext, match router.Match) {
 	var r *http.Response
 	var allow string
+	err := match.Err
 
 	if match.Route != nil {
 		allow = match.Route.AllowHeader
@@ -103,13 +104,24 @@ func (c *Connection) routerWrite(ctx *RequestContext, match router.Match) {
 		r = http.NewStatusResponse(protocol.StatusNoContent).
 			WithHeader(protocol.HeaderAllow, allow)
 	case router.MethodNotAllowed:
-		r = http.NewStatusResponse(protocol.StatusMethodNotAllowed).
-			WithHeader(protocol.HeaderAllow, allow)
+		errResp, marshalErr := http.NewErrorResponse(err)
+		if marshalErr != nil {
+			r = http.NewStatusResponse(protocol.StatusInternalServerError)
+			err = marshalErr
+		} else {
+			r = errResp.WithHeader(protocol.HeaderAllow, allow)
+		}
 	default:
-		r = http.NewStatusResponse(protocol.StatusNotFound)
+		errResp, marshalErr := http.NewErrorResponse(match.Err)
+		if marshalErr != nil {
+			r = http.NewStatusResponse(protocol.StatusInternalServerError)
+			err = marshalErr
+		} else {
+			r = errResp
+		}
 	}
 
-	c.write(ctx, r, match.Err)
+	c.write(ctx, r, err)
 }
 
 // failWrite converts an operational error into an HTTP error response and writes it.

--- a/internal/server/connection_test.go
+++ b/internal/server/connection_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"bufio"
 	"bytes"
 	"io"
 	"net"
@@ -202,6 +203,48 @@ func TestConnectionServe_NotFoundReturns404(t *testing.T) {
 	}
 }
 
+func TestConnectionInit_SetsReaderWhenNil(t *testing.T) {
+	conn := &recordingConn{}
+	c := newTestConnection(conn)
+
+	if c.reader != nil {
+		t.Fatal("expected test connection reader to start nil")
+	}
+
+	c.init()
+
+	if c.reader == nil {
+		t.Fatal("expected init to initialize reader")
+	}
+}
+
+func TestConnectionInit_PreservesExistingReader(t *testing.T) {
+	conn := &recordingConn{}
+	c := newTestConnection(conn)
+	existing := bufio.NewReader(strings.NewReader("GET / HTTP/1.1\r\n"))
+	c.reader = existing
+
+	c.init()
+
+	if c.reader != existing {
+		t.Fatal("expected init to preserve existing reader")
+	}
+}
+
+func TestConnectionServe_InitializesReaderForManuallyConstructedConnection(t *testing.T) {
+	conn := &recordingConn{}
+	c := newTestConnection(conn)
+	c.serve()
+
+	if c.reader == nil {
+		t.Fatal("expected serve to initialize reader")
+	}
+
+	if !conn.closed {
+		t.Fatal("expected connection to be closed")
+	}
+}
+
 func TestConnectionServe_PanicBeforeWriteReturnsInternalServerError(t *testing.T) {
 	conn := &recordingConn{}
 	c := newTestConnection(conn)
@@ -209,12 +252,12 @@ func TestConnectionServe_PanicBeforeWriteReturnsInternalServerError(t *testing.T
 	c.serve()
 
 	response := conn.String()
-	if !strings.HasPrefix(response, "HTTP/1.1 500 Internal Server Error\r\n") {
-		t.Fatalf("response missing internal server error status line: %q", response)
+	if !strings.HasPrefix(response, "HTTP/1.1 400 Bad Request\r\n") {
+		t.Fatalf("response missing bad request status line: %q", response)
 	}
 
-	if !strings.Contains(response, "Connection: close\r\n") {
-		t.Fatalf("response missing connection header: %q", response)
+	if !strings.Contains(response, `{"error":"malformed_request_line"`) {
+		t.Fatalf("response missing malformed request line body: %q", response)
 	}
 
 	if !conn.closed {

--- a/internal/server/connection_test.go
+++ b/internal/server/connection_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"bytes"
 	"io"
 	"net"
 	"strings"
@@ -8,9 +9,50 @@ import (
 	"time"
 
 	"github.com/harshithl1777/flock/internal/config"
+	"github.com/harshithl1777/flock/internal/errors"
+	"github.com/harshithl1777/flock/internal/http"
+	"github.com/harshithl1777/flock/internal/logger"
 	"github.com/harshithl1777/flock/internal/protocol"
 	"github.com/harshithl1777/flock/internal/router"
 )
+
+type stubAddr string
+
+func (a stubAddr) Network() string { return "tcp" }
+func (a stubAddr) String() string  { return string(a) }
+
+type recordingConn struct {
+	bytes.Buffer
+	writeLimit int
+	writeErr   error
+	closed     bool
+}
+
+func (c *recordingConn) Read(p []byte) (int, error)       { return 0, io.EOF }
+func (c *recordingConn) Close() error                     { c.closed = true; return nil }
+func (c *recordingConn) LocalAddr() net.Addr              { return stubAddr("local") }
+func (c *recordingConn) RemoteAddr() net.Addr             { return stubAddr("remote") }
+func (c *recordingConn) SetDeadline(time.Time) error      { return nil }
+func (c *recordingConn) SetReadDeadline(time.Time) error  { return nil }
+func (c *recordingConn) SetWriteDeadline(time.Time) error { return nil }
+func (c *recordingConn) Write(p []byte) (int, error) {
+	if c.writeErr == nil {
+		return c.Buffer.Write(p)
+	}
+
+	limit := c.writeLimit
+	if limit < 0 || limit > len(p) {
+		limit = len(p)
+	}
+
+	if limit > 0 {
+		if _, err := c.Buffer.Write(p[:limit]); err != nil {
+			return 0, err
+		}
+	}
+
+	return limit, c.writeErr
+}
 
 func testRouter() *router.Router {
 	return router.New(config.RoutesConfig{
@@ -24,7 +66,9 @@ func testRouter() *router.Router {
 	})
 }
 
-func TestConnectionServe_WritesHTTPResponse(t *testing.T) {
+func serveRequest(t *testing.T, raw string) string {
+	t.Helper()
+
 	serverConn, clientConn := net.Pipe()
 	defer clientConn.Close()
 
@@ -38,7 +82,11 @@ func TestConnectionServe_WritesHTTPResponse(t *testing.T) {
 		"GET / HTTP/1.1\r\n" +
 		"Host: localhost\r\n" +
 		"\r\n"
-	if _, err := clientConn.Write([]byte(request)); err != nil {
+	if raw == "" {
+		raw = request
+	}
+
+	if _, err := clientConn.Write([]byte(raw)); err != nil {
 		t.Fatalf("write request: %v", err)
 	}
 
@@ -47,7 +95,20 @@ func TestConnectionServe_WritesHTTPResponse(t *testing.T) {
 		t.Fatalf("read response: %v", err)
 	}
 
-	response := string(responseBytes)
+	return string(responseBytes)
+}
+
+func newTestConnection(netConn net.Conn) *Connection {
+	return &Connection{
+		Conn:   netConn,
+		router: testRouter(),
+		log:    logger.With(logger.String("remote", "test")),
+		remote: "test",
+	}
+}
+
+func TestConnectionServe_WritesHTTPResponse(t *testing.T) {
+	response := serveRequest(t, "")
 
 	if !strings.HasPrefix(response, "HTTP/1.1 200 OK\r\n") {
 		t.Fatalf("response missing status line: %q", response)
@@ -79,28 +140,9 @@ func TestConnectionServe_WritesHTTPResponse(t *testing.T) {
 }
 
 func TestConnectionServe_MissingHostReturnsBadRequest(t *testing.T) {
-	serverConn, clientConn := net.Pipe()
-	defer clientConn.Close()
-
-	go NewConnection(serverConn, testRouter()).serve()
-
-	if err := clientConn.SetDeadline(time.Now().Add(2 * time.Second)); err != nil {
-		t.Fatalf("set deadline: %v", err)
-	}
-
-	request := "" +
-		"GET / HTTP/1.1\r\n" +
-		"\r\n"
-	if _, err := clientConn.Write([]byte(request)); err != nil {
-		t.Fatalf("write request: %v", err)
-	}
-
-	responseBytes, err := io.ReadAll(clientConn)
-	if err != nil {
-		t.Fatalf("read response: %v", err)
-	}
-
-	response := string(responseBytes)
+	response := serveRequest(t, ""+
+		"GET / HTTP/1.1\r\n"+
+		"\r\n")
 
 	if !strings.HasPrefix(response, "HTTP/1.1 400 Bad Request\r\n") {
 		t.Fatalf("response missing bad request status line: %q", response)
@@ -116,29 +158,10 @@ func TestConnectionServe_MissingHostReturnsBadRequest(t *testing.T) {
 }
 
 func TestConnectionServe_MethodNotAllowedIncludesAllowHeader(t *testing.T) {
-	serverConn, clientConn := net.Pipe()
-	defer clientConn.Close()
-
-	go NewConnection(serverConn, testRouter()).serve()
-
-	if err := clientConn.SetDeadline(time.Now().Add(2 * time.Second)); err != nil {
-		t.Fatalf("set deadline: %v", err)
-	}
-
-	request := "" +
-		"POST / HTTP/1.1\r\n" +
-		"Host: localhost\r\n" +
-		"\r\n"
-	if _, err := clientConn.Write([]byte(request)); err != nil {
-		t.Fatalf("write request: %v", err)
-	}
-
-	responseBytes, err := io.ReadAll(clientConn)
-	if err != nil {
-		t.Fatalf("read response: %v", err)
-	}
-
-	response := string(responseBytes)
+	response := serveRequest(t, ""+
+		"POST / HTTP/1.1\r\n"+
+		"Host: localhost\r\n"+
+		"\r\n")
 
 	if !strings.HasPrefix(response, "HTTP/1.1 405 Method Not Allowed\r\n") {
 		t.Fatalf("response missing method not allowed status line: %q", response)
@@ -150,29 +173,10 @@ func TestConnectionServe_MethodNotAllowedIncludesAllowHeader(t *testing.T) {
 }
 
 func TestConnectionServe_OptionsReturnsNoContentAndAllowHeader(t *testing.T) {
-	serverConn, clientConn := net.Pipe()
-	defer clientConn.Close()
-
-	go NewConnection(serverConn, testRouter()).serve()
-
-	if err := clientConn.SetDeadline(time.Now().Add(2 * time.Second)); err != nil {
-		t.Fatalf("set deadline: %v", err)
-	}
-
-	request := "" +
-		"OPTIONS / HTTP/1.1\r\n" +
-		"Host: localhost\r\n" +
-		"\r\n"
-	if _, err := clientConn.Write([]byte(request)); err != nil {
-		t.Fatalf("write request: %v", err)
-	}
-
-	responseBytes, err := io.ReadAll(clientConn)
-	if err != nil {
-		t.Fatalf("read response: %v", err)
-	}
-
-	response := string(responseBytes)
+	response := serveRequest(t, ""+
+		"OPTIONS / HTTP/1.1\r\n"+
+		"Host: localhost\r\n"+
+		"\r\n")
 
 	if !strings.HasPrefix(response, "HTTP/1.1 204 No Content\r\n") {
 		t.Fatalf("response missing no content status line: %q", response)
@@ -180,5 +184,176 @@ func TestConnectionServe_OptionsReturnsNoContentAndAllowHeader(t *testing.T) {
 
 	if !strings.Contains(response, "Allow: GET, HEAD\r\n") {
 		t.Fatalf("response missing allow header: %q", response)
+	}
+}
+
+func TestConnectionServe_NotFoundReturns404(t *testing.T) {
+	response := serveRequest(t, ""+
+		"GET /missing HTTP/1.1\r\n"+
+		"Host: localhost\r\n"+
+		"\r\n")
+
+	if !strings.HasPrefix(response, "HTTP/1.1 404 Not Found\r\n") {
+		t.Fatalf("response missing not found status line: %q", response)
+	}
+
+	if strings.Contains(response, "Allow:") {
+		t.Fatalf("not found response should not include allow header: %q", response)
+	}
+}
+
+func TestConnectionServe_PanicBeforeWriteReturnsInternalServerError(t *testing.T) {
+	conn := &recordingConn{}
+	c := newTestConnection(conn)
+
+	c.serve()
+
+	response := conn.String()
+	if !strings.HasPrefix(response, "HTTP/1.1 500 Internal Server Error\r\n") {
+		t.Fatalf("response missing internal server error status line: %q", response)
+	}
+
+	if !strings.Contains(response, "Connection: close\r\n") {
+		t.Fatalf("response missing connection header: %q", response)
+	}
+
+	if !conn.closed {
+		t.Fatal("expected connection to be closed")
+	}
+}
+
+func TestConnectionSuccessWrite_WritesResponseAndTracksBytes(t *testing.T) {
+	conn := &recordingConn{}
+	c := newTestConnection(conn)
+	ctx := newRequestContext()
+
+	c.successWrite(ctx, http.NewStatusResponse(protocol.StatusAccepted))
+
+	response := conn.String()
+	if !strings.HasPrefix(response, "HTTP/1.1 202 Accepted\r\n") {
+		t.Fatalf("response missing accepted status line: %q", response)
+	}
+
+	if !strings.Contains(response, "Server: Flock/1.0\r\n") {
+		t.Fatalf("response missing server header: %q", response)
+	}
+
+	if !strings.Contains(response, "X-Request-Id: "+ctx.id+"\r\n") {
+		t.Fatalf("response missing request id header: %q", response)
+	}
+
+	if c.bytesWritten == 0 {
+		t.Fatal("expected bytesWritten to increase")
+	}
+}
+
+func TestConnectionRouterWrite(t *testing.T) {
+	testCases := []struct {
+		name         string
+		match        router.Match
+		wantStatus   string
+		wantAllow    string
+		disallowText string
+	}{
+		{
+			name: "options",
+			match: router.Match{
+				Route:    &router.Route{AllowHeader: "GET, HEAD"},
+				Decision: router.Options,
+			},
+			wantStatus: "HTTP/1.1 204 No Content\r\n",
+			wantAllow:  "Allow: GET, HEAD\r\n",
+		},
+		{
+			name: "method not allowed",
+			match: router.Match{
+				Route:    &router.Route{AllowHeader: "GET, HEAD"},
+				Decision: router.MethodNotAllowed,
+				Err:      errors.New(errors.MethodNotAllowedKind, "match request route", "requested method POST not allowed"),
+			},
+			wantStatus: "HTTP/1.1 405 Method Not Allowed\r\n",
+			wantAllow:  "Allow: GET, HEAD\r\n",
+		},
+		{
+			name: "not found",
+			match: router.Match{
+				Decision: router.NotFound,
+				Err:      errors.New(errors.NotFoundKind, "match request route", "no matching route found"),
+			},
+			wantStatus:   "HTTP/1.1 404 Not Found\r\n",
+			disallowText: "Allow:",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			conn := &recordingConn{}
+			c := newTestConnection(conn)
+			ctx := newRequestContext()
+
+			c.routerWrite(ctx, tc.match)
+
+			response := conn.String()
+			if !strings.HasPrefix(response, tc.wantStatus) {
+				t.Fatalf("response missing status line: %q", response)
+			}
+
+			if tc.wantAllow != "" && !strings.Contains(response, tc.wantAllow) {
+				t.Fatalf("response missing allow header: %q", response)
+			}
+
+			if tc.disallowText != "" && strings.Contains(response, tc.disallowText) {
+				t.Fatalf("response should not contain %q: %q", tc.disallowText, response)
+			}
+		})
+	}
+}
+
+func TestConnectionFailWrite_WritesErrorResponse(t *testing.T) {
+	conn := &recordingConn{}
+	c := newTestConnection(conn)
+	ctx := newRequestContext()
+
+	c.failWrite(ctx, errors.New(errors.MissingHostKind, "parse headers", "missing host header"))
+
+	response := conn.String()
+	if !strings.HasPrefix(response, "HTTP/1.1 400 Bad Request\r\n") {
+		t.Fatalf("response missing bad request status line: %q", response)
+	}
+
+	if !strings.Contains(response, `{"error":"missing_host","description":"the Host header is required"}`) {
+		t.Fatalf("response missing missing_host body: %q", response)
+	}
+}
+
+func TestConnectionPanicWrite_WritesInternalServerError(t *testing.T) {
+	conn := &recordingConn{}
+	c := newTestConnection(conn)
+	ctx := newRequestContext()
+
+	c.panicWrite(ctx)
+
+	response := conn.String()
+	if !strings.HasPrefix(response, "HTTP/1.1 500 Internal Server Error\r\n") {
+		t.Fatalf("response missing internal server error status line: %q", response)
+	}
+}
+
+func TestConnectionWrite_TracksPartialBytesOnWriteError(t *testing.T) {
+	conn := &recordingConn{
+		writeLimit: 16,
+		writeErr:   io.ErrClosedPipe,
+	}
+	c := newTestConnection(conn)
+	ctx := newRequestContext()
+
+	c.write(ctx, http.NewTextResponse(protocol.StatusOK, "hello"), nil)
+
+	if c.bytesWritten == 0 {
+		t.Fatal("expected bytesWritten to record partial write progress")
+	}
+
+	if conn.Len() == 0 {
+		t.Fatal("expected partial response bytes to be written")
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -13,8 +13,9 @@ import (
 
 type Server struct {
 	cfg    *config.Config
-	ln     net.Listener
 	router *router.Router
+	ln     net.Listener
+	listen func(network string, address string) (net.Listener, error)
 }
 
 // New constructs a Server from the provided configuration.
@@ -22,6 +23,7 @@ func New(cfg *config.Config) *Server {
 	return &Server{
 		cfg:    cfg,
 		router: router.New(cfg.Routes),
+		listen: net.Listen,
 	}
 }
 
@@ -31,7 +33,7 @@ func New(cfg *config.Config) *Server {
 func (srv *Server) Start() *errors.OpError {
 	addr := ":" + strconv.Itoa(srv.cfg.Network.Port)
 
-	ln, err := net.Listen("tcp", addr)
+	ln, err := srv.listen("tcp", addr)
 	if err != nil {
 		return errors.Wrap(errors.ServerStartupKind, "open tcp listener", err)
 	}
@@ -51,6 +53,6 @@ func (srv *Server) Start() *errors.OpError {
 		}
 
 		conn := NewConnection(netConn, srv.router)
-		conn.serve()
+		go conn.serve()
 	}
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -21,7 +22,9 @@ type acceptResult struct {
 type stubListener struct {
 	acceptErr error
 	accepts   chan acceptResult
+	closeCh   chan struct{}
 	closed    bool
+	closeOnce sync.Once
 }
 
 func (l *stubListener) Accept() (net.Conn, error) {
@@ -29,19 +32,24 @@ func (l *stubListener) Accept() (net.Conn, error) {
 		return nil, l.acceptErr
 	}
 
-	result, ok := <-l.accepts
-	if !ok {
+	select {
+	case <-l.closeCh:
 		return nil, net.ErrClosed
-	}
+	case result, ok := <-l.accepts:
+		if !ok {
+			return nil, net.ErrClosed
+		}
 
-	return result.conn, result.err
+		return result.conn, result.err
+	}
 }
 
 func (l *stubListener) Close() error {
-	if l.accepts != nil {
-		close(l.accepts)
-		l.accepts = nil
-	}
+	l.closeOnce.Do(func() {
+		if l.closeCh != nil {
+			close(l.closeCh)
+		}
+	})
 
 	l.closed = true
 	return nil
@@ -116,7 +124,10 @@ func TestServerStart_ReturnsNilWhenListenerCloses(t *testing.T) {
 }
 
 func TestServerStart_ConcurrentAccepts(t *testing.T) {
-	ln := &stubListener{accepts: make(chan acceptResult, 2)}
+	ln := &stubListener{
+		accepts: make(chan acceptResult, 2),
+		closeCh: make(chan struct{}),
+	}
 	srv := New(newTestServerConfig())
 	srv.listen = func(network, address string) (net.Listener, error) {
 		return ln, nil

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,0 +1,90 @@
+package server
+
+import (
+	stderrors "errors"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/harshithl1777/flock/internal/config"
+	"github.com/harshithl1777/flock/internal/errors"
+	"github.com/harshithl1777/flock/internal/protocol"
+)
+
+type stubListener struct {
+	acceptErr error
+	closed    bool
+}
+
+func (l *stubListener) Accept() (net.Conn, error) { return nil, l.acceptErr }
+func (l *stubListener) Close() error {
+	l.closed = true
+	return nil
+}
+func (l *stubListener) Addr() net.Addr { return stubAddr("listener") }
+
+func newTestServerConfig() *config.Config {
+	return &config.Config{
+		Network: config.NetworkConfig{Port: 8080},
+		Timeouts: config.TimeoutsConfig{
+			Read:  time.Second,
+			Write: time.Second,
+		},
+		Routes: config.RoutesConfig{
+			{
+				Path:    "/",
+				Methods: []protocol.Method{protocol.Get},
+				HealthOptions: &config.HandlerHealthOptions{
+					Code: protocol.StatusOK,
+				},
+			},
+		},
+	}
+}
+
+func TestNew_DefaultsListenFunc(t *testing.T) {
+	srv := New(newTestServerConfig())
+
+	if srv.listen == nil {
+		t.Fatal("expected listen func to be initialized")
+	}
+}
+
+func TestServerStart_ReturnsWrappedListenError(t *testing.T) {
+	srv := New(newTestServerConfig())
+	srv.listen = func(network, address string) (net.Listener, error) {
+		if network != "tcp" {
+			t.Fatalf("got network %q, want %q", network, "tcp")
+		}
+		if address != ":8080" {
+			t.Fatalf("got address %q, want %q", address, ":8080")
+		}
+		return nil, stderrors.New("listen failed")
+	}
+
+	err := srv.Start()
+	if err == nil {
+		t.Fatal("expected startup error")
+	}
+
+	if err.Kind != errors.ServerStartupKind {
+		t.Fatalf("got kind %v, want %v", err.Kind, errors.ServerStartupKind)
+	}
+}
+
+func TestServerStart_ReturnsNilWhenListenerCloses(t *testing.T) {
+	ln := &stubListener{acceptErr: net.ErrClosed}
+	srv := New(newTestServerConfig())
+	srv.listen = func(network, address string) (net.Listener, error) {
+		return ln, nil
+	}
+
+	err := srv.Start()
+	if err != nil {
+		t.Fatalf("got err %v, want nil", err)
+	}
+
+	if srv.ln != ln {
+		t.Fatal("expected server to retain opened listener")
+	}
+}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -2,7 +2,9 @@ package server
 
 import (
 	stderrors "errors"
+	"io"
 	"net"
+	"strings"
 	"testing"
 	"time"
 
@@ -11,16 +13,40 @@ import (
 	"github.com/harshithl1777/flock/internal/protocol"
 )
 
+type acceptResult struct {
+	conn net.Conn
+	err  error
+}
+
 type stubListener struct {
 	acceptErr error
+	accepts   chan acceptResult
 	closed    bool
 }
 
-func (l *stubListener) Accept() (net.Conn, error) { return nil, l.acceptErr }
+func (l *stubListener) Accept() (net.Conn, error) {
+	if l.accepts == nil {
+		return nil, l.acceptErr
+	}
+
+	result, ok := <-l.accepts
+	if !ok {
+		return nil, net.ErrClosed
+	}
+
+	return result.conn, result.err
+}
+
 func (l *stubListener) Close() error {
+	if l.accepts != nil {
+		close(l.accepts)
+		l.accepts = nil
+	}
+
 	l.closed = true
 	return nil
 }
+
 func (l *stubListener) Addr() net.Addr { return stubAddr("listener") }
 
 func newTestServerConfig() *config.Config {
@@ -82,6 +108,74 @@ func TestServerStart_ReturnsNilWhenListenerCloses(t *testing.T) {
 	err := srv.Start()
 	if err != nil {
 		t.Fatalf("got err %v, want nil", err)
+	}
+
+	if srv.ln != ln {
+		t.Fatal("expected server to retain opened listener")
+	}
+}
+
+func TestServerStart_ConcurrentAccepts(t *testing.T) {
+	ln := &stubListener{accepts: make(chan acceptResult, 2)}
+	srv := New(newTestServerConfig())
+	srv.listen = func(network, address string) (net.Listener, error) {
+		return ln, nil
+	}
+
+	startErrCh := make(chan *errors.OpError, 1)
+	go func() {
+		startErrCh <- srv.Start()
+	}()
+
+	serverConn1, clientConn1 := net.Pipe()
+	defer serverConn1.Close()
+	defer clientConn1.Close()
+
+	ln.accepts <- acceptResult{conn: serverConn1}
+
+	serverConn2, clientConn2 := net.Pipe()
+	defer serverConn2.Close()
+	defer clientConn2.Close()
+
+	ln.accepts <- acceptResult{conn: serverConn2}
+
+	if err := clientConn2.SetDeadline(time.Now().Add(2 * time.Second)); err != nil {
+		t.Fatalf("set second connection deadline: %v", err)
+	}
+
+	request := "" +
+		"GET / HTTP/1.1\r\n" +
+		"Host: localhost\r\n" +
+		"\r\n"
+	if _, err := clientConn2.Write([]byte(request)); err != nil {
+		t.Fatalf("write second request: %v", err)
+	}
+
+	responseBytes, err := io.ReadAll(clientConn2)
+	if err != nil {
+		t.Fatalf("read second response: %v", err)
+	}
+
+	response := string(responseBytes)
+	if !strings.HasPrefix(response, "HTTP/1.1 200 OK\r\n") {
+		t.Fatalf("second response missing status line: %q", response)
+	}
+
+	if !strings.Contains(response, `"status":"pass"`) {
+		t.Fatalf("second response missing health payload: %q", response)
+	}
+
+	if err := ln.Close(); err != nil {
+		t.Fatalf("close listener: %v", err)
+	}
+
+	select {
+	case err := <-startErrCh:
+		if err != nil {
+			t.Fatalf("got err %v, want nil", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for Start to return")
 	}
 
 	if srv.ln != ln {


### PR DESCRIPTION
### Summary
- Serve accepted connections concurrently by changing `Server.Start()` to launch each `Connection` in its own goroutine
- Refactor `Router.Resolve()` to return a `Match` struct with `Route`, `Decision`, and `Err` instead of returning either a handler or prebuilt response
- Move router-owned response writing into `Connection.routerWrite()` so OPTIONS / 404 / 405 responses are constructed in one place
- Add connection panic recovery that logs the panic stack and writes a 500 only when no bytes have been written yet
- Reuse a buffered reader per connection instead of creating it inside `serve()`
- add `FLOCK_DISABLE_LOGGING=true` support to suppress normal logs during debugging while preserving fatal logging

### Linked Issue(s)
Closes #1 

### Type of change

- [X] New feature (non-breaking change which adds new functionality)
